### PR TITLE
Potential fix for code scanning alert no. 12: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.1",
-    "postgres": "^3.4.7"
+    "postgres": "^3.4.7",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "concurrently": "^9.2.1",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ const morgan = require('morgan');
 const cookieParser = require('cookie-parser');
 const jwt = require('jsonwebtoken');
 
+const { csrf } = require('lusca');
 // Import UAA modules
 const { sql } = require('./db');
 const { authRoutes } = require('./routes/auth');
@@ -104,6 +105,7 @@ async function initializeApp() {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use(cookieParser()); // Add cookie parser for UAA
+  app.use(csrf()); // CSRF protection for all state-changing requests
   app.use(
     cors({
       origin: process.env.FRONTEND_ORIGIN || true, // Allow all origins in development


### PR DESCRIPTION
Potential fix for [https://github.com/fcyap/IS212_G3T5/security/code-scanning/12](https://github.com/fcyap/IS212_G3T5/security/code-scanning/12)

To remedy the missing CSRF middleware, integrate a well-known CSRF protection package, such as `lusca`, as recommended. Specifically, import the `csrf` middleware from `lusca` after all cookie/session handling middleware (i.e., after `cookieParser()` and before defining protected routes). Then, add `app.use(csrf());` to the middleware chain within `initializeApp()`. This approach will prevent CSRF attacks on any state-changing endpoints by ensuring requests carry a valid session-specific token. The fix will only require adding the import for `lusca` and integrating its CSRF middleware within the initialization function shown.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Integrate a well-known CSRF protection package (lusca) by adding it to dependencies and applying its csrf middleware after cookie parsing in the server initialization to address missing CSRF protection alert.

New Features:
- Add CSRF protection middleware using lusca to safeguard state-changing endpoints

Enhancements:
- Require and apply the csrf middleware after cookie parsing in initializeApp

Build:
- Add lusca as a dependency in package.json