### PR TITLE
Fix csrf token on login

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -148,6 +148,9 @@ async function initializeApp() {
     })
   );
 
+    app.get("/csrf-token", (req, res) => {
+        res.json({ csrfToken: req.csrfToken() });
+    });
   // Build a single auth middleware that either enforces session
   // or (when AUTH_BYPASS=true) fakes req.user if no session.
   const authMw = devBypass(requireSession);

--- a/frontend/src/app/login/page.jsx
+++ b/frontend/src/app/login/page.jsx
@@ -10,14 +10,24 @@ export default function LoginPage() {
   const [showPw, setShowPw] = useState(false);
   const [err, setErr] = useState("");
 
+    const getCsrfToken = async () => {
+        const response = await fetch(process.env.NEXT_PUBLIC_API_URL + "/csrf-token", {
+            method: "GET",
+            credentials: "include" // send cookies with the request
+        });
+        const data = await response.json();
+        return data.csrfToken;
+    };
+
   const onSubmit = async (e) => {
     e.preventDefault();
     setErr("");
+      const csrfToken = await getCsrfToken();
     try {
       const res = await fetch(process.env.NEXT_PUBLIC_API_URL + "/auth/supabase-login", {
         method: "POST",
         credentials: "include",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-csrf-token": csrfToken },
         body: JSON.stringify({ email, password: pw }),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary by Sourcery

Expose a CSRF token endpoint and update the login flow to fetch and include the token in authentication requests

New Features:
- Add a GET /csrf-token endpoint on the backend to provide CSRF tokens
- Implement frontend logic to fetch the CSRF token before submitting the login form
- Include the CSRF token in the x-csrf-token header of the login request

Bug Fixes:
- Ensure CSRF protection is applied on login by including the token with credentials